### PR TITLE
chore: fill Claude Code setup gaps

### DIFF
--- a/.claude/hooks/block-dags-edit.sh
+++ b/.claude/hooks/block-dags-edit.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PreToolUse hook — blocks any Edit or Write targeting the dags/ submodule.
+# dags/ is a git submodule; changes must go through the upstream repository.
+set -euo pipefail
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE" ]]; then
+  exit 0
+fi
+
+# Resolve to an absolute path for reliable prefix matching
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [[ -n "$REPO_ROOT" ]]; then
+  DAGS_PATH="$REPO_ROOT/dags"
+  case "$FILE" in
+    "$DAGS_PATH"*|"dags/"*|"./dags/"*)
+      echo "Blocked: dags/ is a git submodule — changes must go through the upstream DAGs repository." >&2
+      exit 2
+      ;;
+  esac
+fi
+
+exit 0

--- a/.claude/hooks/validate-compose.sh
+++ b/.claude/hooks/validate-compose.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PostToolUse hook — runs `make lint` after any edit to a compose file.
+# Prints a warning if lint fails, but does not block (async hook).
+set -euo pipefail
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE" ]]; then
+  exit 0
+fi
+
+case "$FILE" in
+  *compose/*.yaml|*compose/*.yml)
+    REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || echo ".")"
+    cd "$REPO_ROOT"
+    if ! make lint 2>&1; then
+      echo "" >&2
+      echo "WARNING: compose lint failed after editing $FILE — fix before committing." >&2
+      exit 1
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/.claude/rules/airflow.md
+++ b/.claude/rules/airflow.md
@@ -1,0 +1,42 @@
+---
+paths:
+  - "compose/docker-compose.airflow*"
+  - "config/airflow*"
+  - "config/secrets.yaml"
+---
+
+# Airflow 3 Rules
+
+## Import Namespace
+
+Always use the Airflow 3 SDK namespace:
+
+```python
+from airflow.sdk import DAG, dag, task, asset
+```
+
+Never use the legacy import:
+```python
+from airflow import DAG  # WRONG — breaks on Airflow 3
+```
+
+## Health Check Endpoint
+
+The correct health endpoint is:
+```
+GET /api/v2/monitor/health
+```
+Not `/health` (that is the Airflow 2 path).
+
+## Environment Variables
+
+| Variable | Correct | Wrong |
+|---|---|---|
+| JWT secret | `AIRFLOW__API_AUTH__JWT_SECRET` | `AIRFLOW__API__JWT_SECRET` |
+| Execution API | `AIRFLOW__CORE__EXECUTION_API_SERVER_URL` | — |
+
+The scheduler requires `AIRFLOW__CORE__EXECUTION_API_SERVER_URL` to reach `airflow-api-server`.
+
+## DAGs Submodule
+
+The `dags/` directory is a **git submodule**. Never edit files there directly. All DAG changes must go through the upstream DAGs repository.

--- a/.claude/rules/compose.md
+++ b/.claude/rules/compose.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "compose/**"
+---
+
+# Docker Compose Rules
+
+## Mandatory Patterns
+
+- All `depends_on` entries MUST use `condition: service_healthy` or `condition: service_completed_successfully` — bare `depends_on` causes race conditions on startup
+- Never use `latest` image tags — always pin an explicit version (e.g. `postgres:16-alpine`)
+- Every stateful service MUST have a `healthcheck` block before any downstream service can depend on it
+- Every service MUST belong to a named Docker network — never use `network_mode: host`
+- Every service MUST be assigned a profile — never add a service to the default (profileless) set
+- Secrets go in `.env.local` only, never in compose files — reference them via `${VAR_NAME}` only
+
+## After Any Edit
+
+Run `make lint` to validate all compose files parse correctly before considering the change done.
+
+## Adding a New Service
+
+1. Add to the appropriate `compose/docker-compose.<group>.yaml` (or create a new file — it is auto-included by the makefile glob)
+2. Assign a profile
+3. Add a `healthcheck` block
+4. Add corresponding `make` targets in `scripts/make/*.mk`
+5. Add a `## Description` comment on each new make target for `make help`
+
+## Hostnames
+
+Services communicate over named Docker networks. Use service names as hostnames:
+- `postgres:5432` not `localhost:5432`
+- `minio:9000` not `localhost:9000`

--- a/.claude/rules/kubernetes.md
+++ b/.claude/rules/kubernetes.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "cluster/**"
+  - "helm/**"
+---
+
+# Kubernetes Rules
+
+## Single Registry
+
+`cluster/helm-components.yaml` is the ONLY registry for Kubernetes components. All deploy, remove, and port-forward logic reads from this file. Never run `helm install` manually.
+
+## Adding a Component
+
+1. Register it in `cluster/helm-components.yaml`
+2. Set resource limits in `helm/<component>/values.yaml` — never leave limits unset
+3. Use `condition: service_healthy` in any `depends_on` entries inside the YAML registry
+4. Test with `make kube-deploy-one COMPONENT=<name>` before running `make kube-up`
+
+## Security Constraints
+
+- Never bind `cluster-admin` to a workload service account
+- Never use `network_mode: host` — use named networks
+- Never put real secrets in Helm values files — reference `.env.local` vars only
+
+## Useful Make Targets
+
+- `make kube-up` — bring up all registered components
+- `make kube-down` — tear down all components
+- `make kube-deploy-one COMPONENT=<name>` — deploy a single component
+- `make kube-remove-one COMPONENT=<name>` — remove a single component

--- a/.claude/rules/makefile.md
+++ b/.claude/rules/makefile.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "makefile"
+  - "scripts/make/**"
+---
+
+# Makefile Rules
+
+## Every Operation Needs a Target
+
+Every new repeatable operation must have a `make` target. Users and CI interact exclusively through `make` — never via raw `docker compose`, `helm`, or `kubectl` directly.
+
+## Required for Every New Target
+
+```makefile
+.PHONY: my-target
+my-target: ## Brief description shown in make help
+	@command-here
+```
+
+- Declare in `.PHONY`
+- Add a `## Description` comment on the same line — `make help` parses this format
+- Group the target under the appropriate sub-makefile in `scripts/make/*.mk`
+
+## Organisation
+
+Sub-makefiles are included by the root makefile glob. Adding a new `.mk` file in `scripts/make/` is enough — no manual registration needed.
+
+## Never Expose docker compose Directly
+
+All Docker Compose operations must go through `make` targets. This ensures consistent env var loading, profile handling, and `.env.local` injection.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Bash(make *)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git fetch *)",
+      "Bash(git checkout *)",
+      "Bash(git branch *)",
+      "Bash(git show *)",
+      "Bash(git stash *)"
+    ],
+    "ask": [
+      "Bash(docker *)",
+      "Bash(kubectl *)",
+      "Bash(helm *)",
+      "Bash(kind *)",
+      "WebFetch"
+    ],
+    "deny": [
+      "Bash(docker compose *)",
+      "Bash(docker-compose *)",
+      "Bash(rm -rf *)"
+    ],
+    "defaultMode": "default"
+  },
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-dags-edit.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/validate-compose.sh",
+            "async": true,
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,35 @@
+# DAGs submodule — read-only; changes must go through the upstream repo
+dags/
+
+# Generated chart output
+*/chart/*
+
+# Logs and temporary files
+**/logs/**
+**/*.log
+*.tmp
+
+# Secrets — belt-and-suspenders on top of .gitignore
+.env.local
+**/*.pem
+**/*.key
+**/*.pfx
+**/*kubeconfig*
+
+# Python artifacts
+**/__pycache__/
+**/*.pyc
+**/.venv/
+
+# Helm dependency cache
+**/charts/
+helm/**/Chart.lock
+
+# OS and editor noise
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/
+
+# Git internals
+.git/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,26 @@
 
 Guidance for Claude Code when working in this repository.
 
-For full project documentation see **[README.md](README.md)**.
-For contribution workflow and change guidelines see **[CONTRIBUTING.md](CONTRIBUTING.md)**.
+For full project documentation see @README.md.
+For contribution workflow and change guidelines see @CONTRIBUTING.md.
+
+---
+
+## Quick Commands
+
+| Command | Purpose |
+|---------|---------|
+| `make ps` | Show all running services and their status |
+| `make health` | Check health of all services |
+| `make lint` | Validate all compose files parse correctly |
+| `make up PROFILES=<p>` | Start services for a given profile |
+| `make down` | Stop all services |
+| `make logs SERVICE=<s>` | Tail logs for a specific service |
+| `make secrets` | Generate secrets from `config/secrets.yaml` |
+| `make rotate KEYS=MY_KEY` | Rotate a specific secret |
+| `make kube-up` | Bring up all Kubernetes components |
+| `make kube-down` | Tear down all Kubernetes components |
+| `make kube-deploy-one COMPONENT=<n>` | Deploy a single Helm component |
 
 ---
 


### PR DESCRIPTION
- Add .claude/settings.json with permission allowlist/denylist (blocks
  raw docker compose, guards kubectl/helm behind ask), and PreToolUse /
  PostToolUse hooks wiring in the two new hook scripts
- Add .claudeignore to exclude dags/ submodule, logs, generated chart
  output, secrets, and build artefacts from Claude's context
- Add .claude/rules/ with four path-scoped rule files that load only
  when Claude edits relevant files (compose, kubernetes, airflow, makefile)
- Add .claude/hooks/block-dags-edit.sh (PreToolUse) to hard-block any
  edit to the dags/ git submodule
- Add .claude/hooks/validate-compose.sh (PostToolUse async) to run
  make lint automatically after any compose file edit
- Add .claude/mcp.json to document the GitHub MCP server dependency
  required by the push-changes command
- Update CLAUDE.md: swap prose file links for @-imports, add Quick
  Commands reference table

https://claude.ai/code/session_01TKb2hzbx4fE3TRCaSpYad2