### PR TITLE
feat: helm chart validation, atomic deploys, and minio values

### DIFF
--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -1,0 +1,69 @@
+# ============================================================
+# MinIO — Helm Chart Values
+# Target: local kind cluster (single-node)
+# Chart:  minio/minio
+# Status: disabled by default (set enabled: true in helm-components.yaml)
+# ============================================================
+
+# ── Mode ──────────────────────────────────────────────────────
+# Standalone mode is sufficient for local dev; no distributed/HA needed.
+mode: standalone
+
+# ── Credentials ───────────────────────────────────────────────
+# Reference env vars from .env.local — never hardcode secrets here.
+rootUser: "minio"
+rootPassword: "minio123"
+
+# ── Persistence ───────────────────────────────────────────────
+persistence:
+  enabled: true
+  size: 5Gi
+  storageClass: standard
+
+# ── Resources ─────────────────────────────────────────────────
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# ── Service ───────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 9000
+
+consoleService:
+  type: ClusterIP
+  port: 9001
+
+# ── Ingress ───────────────────────────────────────────────────
+ingress:
+  enabled: false
+
+consoleIngress:
+  enabled: false
+
+# ── Health probes ─────────────────────────────────────────────
+# Extended for resource-constrained kind nodes.
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 5
+
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  timeoutSeconds: 10
+  failureThreshold: 5
+
+# ── Buckets (created on startup) ──────────────────────────────
+buckets:
+  - name: warehouse
+    policy: none
+    purge: false
+  - name: raw
+    policy: none
+    purge: false

--- a/makefile
+++ b/makefile
@@ -243,6 +243,22 @@ helm-repos: ## Add and update Helm repos for all enabled components
 ##@ Kubernetes — Cluster
 # =============================================================================
 
+# =============================================================================
+##@ Kubernetes — Validation
+# =============================================================================
+
+.PHONY: kube-validate
+kube-validate: ## Validate helm-components.yaml: fields, file refs, dep cycles
+	@bash $(SCRIPTS_DIR)/kube-validate.sh
+
+.PHONY: kube-validate-render
+kube-validate-render: helm-repos ## Validate + helm template dry-run (no cluster needed)
+	@bash $(SCRIPTS_DIR)/kube-validate.sh --render
+
+# =============================================================================
+##@ Kubernetes — Cluster
+# =============================================================================
+
 .PHONY: kube-start
 kube-start: check-deps ## Create the local Kind cluster
 	@if kind get clusters 2>/dev/null | grep -qx "$(CLUSTER_NAME)"; then \

--- a/scripts/kube-deploy.sh
+++ b/scripts/kube-deploy.sh
@@ -36,6 +36,11 @@ if [[ -n "$TARGET" ]]; then
   $found || die "Component '${TARGET}' not found or not enabled in config."
 fi
 
+# ── Pre-flight: assert all file references exist before touching the cluster ──
+log_info "Pre-flight: checking file references..."
+validate_enabled_files
+log_ok "Pre-flight OK"
+
 # ── Resolve deployment order via topological sort ────────────────────────────
 log_info "Resolving deployment order..."
 ordered_indices=$(topo_sort_indices)
@@ -78,16 +83,16 @@ for idx in $ordered_indices; do
     fi
   done < <(enabled_manifests "$idx")
 
-  # Validate values file
-  if [[ ! -f "$values_file" ]]; then
-    die "Values file not found: $values_file"
-  fi
-
   # Helm upgrade --install
+  # --atomic:           roll back to previous revision on upgrade failure
+  # --cleanup-on-fail:  delete newly created resources on a failed install/upgrade
+  # --wait + --timeout: block until all resources are ready
   log_info "  Running helm upgrade --install..."
   helm upgrade --install "$name" "$chart" \
     --namespace "$namespace" \
     --values "$values_file" \
+    --atomic \
+    --cleanup-on-fail \
     --wait \
     --timeout "$wait_timeout"
 

--- a/scripts/kube-validate.sh
+++ b/scripts/kube-validate.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/kube-validate.sh
+# Pre-flight validation for cluster/helm-components.yaml.
+# No running cluster required for static checks.
+#
+# Exit code 0 = all checks passed.
+# Exit code 1 = one or more errors (printed to stderr via log_error).
+#
+# Usage:
+#   ./scripts/kube-validate.sh            # static checks only
+#   ./scripts/kube-validate.sh --render   # + helm template dry-run (needs repos)
+# =============================================================================
+set -euo pipefail
+source "$(dirname "$0")/lib/kube-common.sh"
+
+require_yq
+require_helm
+
+RENDER=false
+[[ "${1:-}" == "--render" ]] && RENDER=true
+
+errors=0
+warnings=0
+
+fail()  { log_error "$*"; errors=$(( errors + 1 )); }
+warn()  { log_warn  "$*"; warnings=$(( warnings + 1 )); }
+
+log_step "Helm Components Validation"
+log_info "Config: $HELM_COMPONENTS_CONFIG"
+echo ""
+
+# ── 1. YAML parse ─────────────────────────────────────────────────────────────
+log_info "1/5  YAML syntax..."
+if ! yq '.' "$HELM_COMPONENTS_CONFIG" > /dev/null 2>&1; then
+  fail "YAML parse error in $HELM_COMPONENTS_CONFIG"
+  exit 1
+fi
+log_ok "     YAML syntax OK"
+
+# ── 2. Required fields + file references ──────────────────────────────────────
+REQUIRED_FIELDS=(name chart helm_repo helm_repo_url namespace values_file wait_timeout)
+total=$(yq '.components | length' "$HELM_COMPONENTS_CONFIG")
+
+log_info "2/5  Required fields ($total component(s))..."
+
+for i in $(seq 0 $(( total - 1 ))); do
+  cname=$(yq ".components[$i].name" "$HELM_COMPONENTS_CONFIG")
+  enabled=$(yq ".components[$i].enabled" "$HELM_COMPONENTS_CONFIG")
+
+  for field in "${REQUIRED_FIELDS[@]}"; do
+    val=$(yq ".components[$i].${field}" "$HELM_COMPONENTS_CONFIG")
+    if [[ "$val" == "null" || -z "$val" ]]; then
+      fail "Component '$cname': missing required field '$field'"
+    fi
+  done
+
+  # enabled must be an explicit boolean
+  if [[ "$enabled" != "true" && "$enabled" != "false" ]]; then
+    fail "Component '$cname': 'enabled' must be true or false, got: '$enabled'"
+  fi
+done
+
+[[ $errors -eq 0 ]] && log_ok "     All required fields present"
+
+# ── 3. File reference checks ───────────────────────────────────────────────────
+log_info "3/5  File references..."
+
+for i in $(seq 0 $(( total - 1 ))); do
+  cname=$(yq ".components[$i].name" "$HELM_COMPONENTS_CONFIG")
+  enabled=$(yq ".components[$i].enabled" "$HELM_COMPONENTS_CONFIG")
+  values_rel=$(yq ".components[$i].values_file" "$HELM_COMPONENTS_CONFIG")
+  values_abs="${REPO_ROOT}/${values_rel}"
+
+  if [[ ! -f "$values_abs" ]]; then
+    if [[ "$enabled" == "true" ]]; then
+      fail "Component '$cname' (enabled): values_file not found: $values_rel"
+    else
+      warn "Component '$cname' (disabled): values_file not found: $values_rel"
+    fi
+  fi
+
+  manifest_count=$(yq ".components[$i].pre_manifests | length" "$HELM_COMPONENTS_CONFIG")
+  for m in $(seq 0 $(( manifest_count - 1 ))); do
+    mrel=$(yq ".components[$i].pre_manifests[$m]" "$HELM_COMPONENTS_CONFIG")
+    mabs="${REPO_ROOT}/${mrel}"
+    if [[ ! -f "$mabs" ]]; then
+      if [[ "$enabled" == "true" ]]; then
+        fail "Component '$cname' (enabled): pre_manifest not found: $mrel"
+      else
+        warn "Component '$cname' (disabled): pre_manifest not found: $mrel"
+      fi
+    fi
+  done
+done
+
+[[ $errors -eq 0 ]] && log_ok "     File references OK"
+
+# ── 4. Dependency cycle check ─────────────────────────────────────────────────
+log_info "4/5  Dependency cycles..."
+if topo_sort_indices > /dev/null 2>&1; then
+  log_ok "     No cycles detected"
+else
+  fail "Circular dependency detected in $HELM_COMPONENTS_CONFIG"
+fi
+
+# ── 5. Helm template dry-run (optional) ───────────────────────────────────────
+if $RENDER; then
+  log_info "5/5  Helm template dry-run (enabled components)..."
+  count=$(count_enabled)
+
+  if [[ "$count" -eq 0 ]]; then
+    log_warn "     No enabled components — skipping render."
+  else
+    for i in $(seq 0 $(( count - 1 ))); do
+      name=$(enabled_field "$i" name)
+      chart=$(enabled_field "$i" chart)
+      namespace=$(enabled_field "$i" namespace)
+      values_rel=$(enabled_field "$i" values_file)
+      values_abs="${REPO_ROOT}/${values_rel}"
+
+      log_info "     Rendering: $name ($chart)..."
+
+      if [[ ! -f "$values_abs" ]]; then
+        log_warn "     Skipping '$name': values_file missing (already reported above)"
+        continue
+      fi
+
+      render_out=$(helm template "$name" "$chart" \
+        --namespace "$namespace" \
+        --values "$values_abs" 2>&1) && rc=0 || rc=$?
+
+      if [[ $rc -eq 0 ]]; then
+        log_ok "     $name: template OK"
+      else
+        fail "Component '$name': helm template failed"
+        echo "$render_out" | head -30 >&2
+      fi
+    done
+  fi
+else
+  log_info "5/5  Helm template dry-run skipped (pass --render to enable)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+if [[ $warnings -gt 0 ]]; then
+  log_warn "$warnings warning(s) — review disabled components above."
+fi
+
+if [[ $errors -gt 0 ]]; then
+  log_error "Validation FAILED — $errors error(s). Fix the issues above before deploying."
+  exit 1
+fi
+
+log_ok "Validation passed (${total} component(s) checked, ${warnings} warning(s))."

--- a/scripts/lib/kube-common.sh
+++ b/scripts/lib/kube-common.sh
@@ -96,6 +96,40 @@ component_port_forwards() {
     "$HELM_COMPONENTS_CONFIG" 2>/dev/null
 }
 
+# ── Pre-flight file-reference check ──────────────────────────────────────────
+# Asserts that the values_file and every pre_manifest for ALL enabled components
+# exist on disk before any helm operation starts.  Call once at the top of
+# kube-deploy.sh so failures are reported together, not mid-deployment.
+validate_enabled_files() {
+  local count errs=0
+  count=$(count_enabled)
+  for i in $(seq 0 $(( count - 1 ))); do
+    local name values_rel values_abs manifest_count m mrel mabs
+    name=$(enabled_field "$i" name)
+    values_rel=$(enabled_field "$i" values_file)
+    values_abs="${REPO_ROOT}/${values_rel}"
+
+    if [[ ! -f "$values_abs" ]]; then
+      log_error "Component '$name': values_file not found: $values_rel"
+      errs=$(( errs + 1 ))
+    fi
+
+    manifest_count=$(yq "[.components[] | select(.enabled == true)][$i].pre_manifests | length" \
+      "$HELM_COMPONENTS_CONFIG" 2>/dev/null || echo 0)
+    for m in $(seq 0 $(( manifest_count - 1 ))); do
+      mrel=$(yq "[.components[] | select(.enabled == true)][$i].pre_manifests[$m]" \
+        "$HELM_COMPONENTS_CONFIG" 2>/dev/null)
+      [[ "$mrel" == "null" || -z "$mrel" ]] && continue
+      mabs="${REPO_ROOT}/${mrel}"
+      if [[ ! -f "$mabs" ]]; then
+        log_error "Component '$name': pre_manifest not found: $mrel"
+        errs=$(( errs + 1 ))
+      fi
+    done
+  done
+  [[ $errs -eq 0 ]] || die "Pre-flight check failed — $errs missing file(s). Aborting before any deploy."
+}
+
 # ── Topological sort ──────────────────────────────────────────────────────────
 # Writes an ordered list of component *indices* (into the enabled array) to stdout.
 # Uses Kahn's algorithm; exits non-zero on cycle detection.


### PR DESCRIPTION
Add pre-flight validation pipeline and harden the deploy process:

- scripts/kube-validate.sh: new script that checks YAML syntax, required
  fields, values_file/pre_manifest paths, and dependency cycles without
  touching the cluster; --render flag adds helm template dry-run
- scripts/lib/kube-common.sh: add validate_enabled_files() helper so the
  pre-flight check is reusable across scripts
- scripts/kube-deploy.sh: call validate_enabled_files() before the deploy
  loop (fail fast instead of mid-deployment); add --atomic and
  --cleanup-on-fail to helm upgrade --install for automatic rollback on failure
- makefile: add kube-validate and kube-validate-render targets under a new
  Kubernetes — Validation section
- helm/minio/values.yaml: add missing values file for the disabled MinIO
  component so kube-validate passes without warnings on a fresh checkout

https://claude.ai/code/session_01QaVz5RwV1FvaVxVkgpLeLv