### PR TITLE
feat: add observability stack (Prometheus + Grafana + cAdvisor)

### DIFF
--- a/.env
+++ b/.env
@@ -38,3 +38,10 @@ AWS_REGION=us-east-1
 AIRFLOW_VAR_ENVIRONMENT=local
 AIRFLOW__WEBSERVER__BASE_URL=http://localhost/airflow
 
+# ── Observability ─────────────────────────────────────────────
+PROMETHEUS_VERSION=v2.53.2
+GRAFANA_VERSION=11.1.4
+CADVISOR_VERSION=v0.49.1
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,19 @@ The `make setup` step is required only once per clone. It activates `.githooks/p
 
 ```
 compose/          # One yaml per service group, auto-included by makefile glob
-scripts/make/     # Sub-makefiles included by root makefile (query, mock, ollama, proxy)
+  prometheus/     # Prometheus scrape config
+  grafana/        # Grafana provisioning (datasources, dashboards)
+  fluentd/        # Fluentd Dockerfile + fluent.conf
+  iceberg-rest/   # Custom Iceberg REST Dockerfile + entrypoint
+  trino/          # Trino catalog and node config
+  nginx/          # Nginx config and virtual host
+  wiremock/       # WireMock stub mappings and response files
+scripts/make/     # Sub-makefiles included by root makefile
+                  #   query.mk, mock.mk, ollama.mk, proxy.mk, observability.mk
 scripts/          # Shell scripts for cluster ops, secret gen, health checks
 cluster/          # Kind config + helm-components.yaml (Kubernetes deployment registry)
 helm/             # Helm values files per component
-config/           # Per-service config files (Trino catalog, Postgres init, WireMock stubs)
+config/           # Per-service config files and secrets.yaml
 dags/             # Git submodule (airflow3-by-example) — do not edit directly here
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Local Infrastructure Setup
 
-A modular Docker Compose–based local data engineering platform covering object storage, distributed SQL, workflow orchestration, centralised log shipping, and Kubernetes deployment.
+A modular Docker Compose–based local data engineering platform covering object storage, distributed SQL, workflow orchestration, centralised log shipping, observability, and Kubernetes deployment.
 
 - [Local Infrastructure Setup](#local-infrastructure-setup)
   - [Overview](#overview)
@@ -15,6 +15,7 @@ A modular Docker Compose–based local data engineering platform covering object
   - [Query Engine](#query-engine)
   - [WireMock Mock Server](#wiremock-mock-server)
   - [Nginx Reverse Proxy](#nginx-reverse-proxy)
+  - [Observability Stack](#observability-stack)
   - [Airflow DAG Validation](#airflow-dag-validation)
   - [Iceberg REST Image](#iceberg-rest-image)
   - [Kubernetes (Kind) Deployment](#kubernetes-kind-deployment)
@@ -35,6 +36,7 @@ A modular Docker Compose–based local data engineering platform covering object
 | Log Shipping | Fluentd | 24224 | Centralised log aggregation → MinIO | ✅ | ❌ |
 | Mock Server | WireMock 3.10 | 8090 | HTTP API mocking for development | ✅ | ✅ |
 | Reverse Proxy | Nginx | 80 | Unified ingress for all services | ✅ | ✅ |
+| Observability | Prometheus + Grafana | 9090 (Prometheus), 3000 (Grafana) | Container metrics collection and visualisation | ✅ | ❌ |
 
 ---
 
@@ -156,6 +158,12 @@ flowchart TD
         airflow_api["airflow-api-server\nUI + REST API\n:8081"]
     end
 
+    subgraph OBS["📊 Observability Stack"]
+        cadvisor["cAdvisor\ncontainer metrics"]
+        prometheus["Prometheus\n:9090"]
+        grafana["Grafana\n:3000"]
+    end
+
     minio          -- "healthy"    --> minio_init
     minio          -- "healthy"    --> fluentd
 
@@ -173,6 +181,9 @@ flowchart TD
 
     airflow_scheduler -. "log driver" .-> fluentd
     airflow_api       -. "log driver" .-> fluentd
+
+    cadvisor       -. "scrape"     .-> prometheus
+    prometheus     -- "healthy"    --> grafana
 ```
 
 > **Legend**
@@ -188,6 +199,9 @@ flowchart TD
 | `docker-compose.logging.yaml` | `logging`, `pipeline` | `fluentd` |
 | `docker-compose.query.yaml` | `query` | `iceberg-rest`, `trino` |
 | `docker-compose.pipeline.yaml` | `pipeline` | `airflow-init`, `airflow-scheduler`, `airflow-api-server` |
+| `docker-compose.mock.yaml` | `mock` | `wiremock` |
+| `docker-compose.proxy.yaml` | `proxy` | `nginx` |
+| `docker-compose.observability.yaml` | `observability` | `prometheus`, `grafana`, `cadvisor` |
 
 ### Common Commands
 
@@ -205,6 +219,9 @@ make up PROFILE=pipeline
 
 # Full stack + nginx reverse proxy
 make proxy-up
+
+# Observability stack (Prometheus + Grafana + cAdvisor)
+make obs-up
 
 # Stop all services
 make down
@@ -271,6 +288,40 @@ make proxy-down    # Stop full stack + proxy
 make proxy-logs    # Tail nginx logs
 make proxy-reload  # Hot-reload nginx config (no downtime)
 ```
+
+---
+
+## Observability Stack
+
+Prometheus scrapes per-container metrics from cAdvisor. Grafana auto-provisions the Prometheus datasource and a pre-built Docker Containers dashboard (CPU, memory, and network I/O panels with a container-name variable filter).
+
+```bash
+make obs-up                         # Start observability stack (profile: observability)
+make obs-down                       # Stop observability stack
+make obs-logs SERVICE=grafana       # Tail logs for a specific service
+make obs-logs SERVICE=prometheus
+make obs-logs SERVICE=cadvisor
+```
+
+| URL | Service |
+|-----|---------|
+| `http://localhost:3000` | Grafana (login: `admin` / see `.env.local` for `GRAFANA_ADMIN_PASSWORD`) |
+| `http://localhost:9090` | Prometheus |
+
+The Grafana admin password is generated on first `make secrets` and stored in `.env.local`. To rotate it:
+
+```bash
+make rotate KEYS=GRAFANA_ADMIN_PASSWORD
+```
+
+Config files:
+
+| Path | Purpose |
+|------|---------|
+| `compose/prometheus/prometheus.yml` | Scrape targets (Prometheus self + cAdvisor) |
+| `compose/grafana/provisioning/datasources/prometheus.yaml` | Auto-provisions the Prometheus datasource |
+| `compose/grafana/provisioning/dashboards/dashboard.yaml` | Dashboard file provider config |
+| `compose/grafana/provisioning/dashboards/containers.json` | Docker Containers dashboard |
 
 ---
 
@@ -366,6 +417,7 @@ The root `makefile` includes sub-makefiles from `scripts/make/`:
 - `mock.mk` — WireMock targets
 - `ollama.mk` — Ollama LLM targets
 - `proxy.mk` — Nginx reverse proxy targets
+- `observability.mk` — Prometheus, Grafana, cAdvisor targets
 
 ### Kubernetes Deployment
 

--- a/compose/docker-compose.observability.yaml
+++ b/compose/docker-compose.observability.yaml
@@ -1,0 +1,120 @@
+# ============================================================
+# docker-compose.observability.yaml
+# Metrics collection and visualisation via Prometheus + Grafana.
+# Container metrics are scraped from cAdvisor.
+# Profile: observability
+#
+# Start with:
+#   make obs-up
+# or:
+#   docker compose --profile observability up -d
+#
+# Grafana UI  → http://localhost:${GRAFANA_PORT:-3000}
+#   Login: admin / (see .env.local for GRAFANA_ADMIN_PASSWORD)
+#
+# Prometheus  → http://localhost:${PROMETHEUS_PORT:-9090}
+#
+# cAdvisor scrapes all running containers and exposes them as
+# Prometheus metrics; it is internal-only (no host port).
+# ============================================================
+
+services:
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION}
+    profiles: [observability]
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=15d
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 256M
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION}
+    profiles: [observability]
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER:     ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD must be set in .env.local}
+      GF_PATHS_PROVISIONING:      /etc/grafana/provisioning
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 256M
+
+  # cAdvisor exposes per-container CPU, memory, network, and filesystem
+  # metrics to Prometheus. Requires privileged mode to read cgroup data.
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:${CADVISOR_VERSION}
+    profiles: [observability]
+    restart: unless-stopped
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.3"
+          memory: 256M
+        reservations:
+          cpus: "0.05"
+          memory: 64M
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/compose/grafana/provisioning/dashboards/containers.json
+++ b/compose/grafana/provisioning/dashboards/containers.json
@@ -1,0 +1,186 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Docker container metrics collected by cAdvisor",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\",name=~\"$container\"}[2m])) by (name)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "container_memory_usage_bytes{image!=\"\",name=~\"$container\"}",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(container_network_receive_bytes_total{image!=\"\",name=~\"$container\"}[2m])) by (name)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Network Receive",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(container_network_transmit_bytes_total{image!=\"\",name=~\"$container\"}[2m])) by (name)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Network Transmit",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["docker", "cadvisor", "containers"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(container_cpu_usage_seconds_total{image!=\"\"}, name)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "name": "container",
+        "options": [],
+        "query": {
+          "query": "label_values(container_cpu_usage_seconds_total{image!=\"\"}, name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "label": "Container"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Docker Containers",
+  "uid": "docker-containers",
+  "version": 1
+}

--- a/compose/grafana/provisioning/dashboards/dashboard.yaml
+++ b/compose/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: Docker
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/compose/grafana/provisioning/datasources/prometheus.yaml
+++ b/compose/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s

--- a/compose/prometheus/prometheus.yml
+++ b/compose/prometheus/prometheus.yml
@@ -1,0 +1,21 @@
+# ============================================================
+# prometheus.yml — scrape configuration for local-infra-setup
+#
+# Jobs:
+#   prometheus  — Prometheus self-metrics
+#   cadvisor    — per-container CPU / memory / network / fs
+# ============================================================
+
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ['cadvisor:8080']

--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -106,3 +106,8 @@ secrets:
   - key:    AIRFLOW_ADMIN_EMAIL
     method: static
     value:  admin@example.com
+
+  # ── Grafana ────────────────────────────────────────────────
+  - key:    GRAFANA_ADMIN_PASSWORD
+    method: random_hex
+    length: 16

--- a/makefile
+++ b/makefile
@@ -28,6 +28,7 @@ include scripts/make/mock.mk
 include scripts/make/ollama.mk
 include scripts/make/proxy.mk
 include scripts/make/security.mk
+include scripts/make/observability.mk
 
 # Export so scripts can inherit without re-reading
 export KIND_CLUSTER_NAME := $(CLUSTER_NAME)

--- a/scripts/make/observability.mk
+++ b/scripts/make/observability.mk
@@ -1,0 +1,27 @@
+# ── Observability stack (Prometheus · Grafana · cAdvisor) ────
+
+obs-up: .env ## Start observability stack (Prometheus, Grafana, cAdvisor)
+	@echo "📊 Starting observability stack..."
+	docker compose $(ENV_FILE_FLAGS) \
+		--profile observability \
+		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
+		up -d --remove-orphans
+	@echo ""
+	@echo "🚀 Observability stack is up:"
+	@echo "   Grafana     → http://localhost:$${GRAFANA_PORT:-3000}"
+	@echo "   Prometheus  → http://localhost:$${PROMETHEUS_PORT:-9090}"
+	@echo ""
+	@echo "   Login: admin / (see .env.local for GRAFANA_ADMIN_PASSWORD)"
+	@echo ""
+
+obs-down: ## Stop observability stack
+	docker compose $(ENV_FILE_FLAGS) \
+		--profile observability \
+		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
+		down
+
+obs-logs: ## Tail observability logs  (SERVICE=prometheus|grafana|cadvisor)
+	docker compose $(ENV_FILE_FLAGS) \
+		--profile observability \
+		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
+		logs -f $(SERVICE)


### PR DESCRIPTION
## Summary

- Adds a new `observability` Docker Compose profile with Prometheus, Grafana, and cAdvisor
- Grafana auto-provisions the Prometheus datasource and a Docker Containers dashboard (CPU, memory, network I/O)
- cAdvisor scrapes per-container cgroup metrics; Prometheus stores them with 15-day retention
- `GRAFANA_ADMIN_PASSWORD` added to `config/secrets.yaml` — generated by `make secrets`, never hardcoded
- Version pins added to `.env`; `obs-up` / `obs-down` / `obs-logs` targets added via `scripts/make/observability.mk`
- README and CONTRIBUTING updated: overview table, compose files table, dependency diagram, new Observability Stack section, project structure tree

## New files

| Path | Purpose |
|------|---------|
| `compose/docker-compose.observability.yaml` | Compose services for prometheus, grafana, cadvisor |
| `compose/prometheus/prometheus.yml` | Scrape config (self + cadvisor) |
| `compose/grafana/provisioning/datasources/prometheus.yaml` | Auto-provisions Prometheus datasource |
| `compose/grafana/provisioning/dashboards/dashboard.yaml` | Dashboard file-provider config |
| `compose/grafana/provisioning/dashboards/containers.json` | Docker Containers dashboard |
| `scripts/make/observability.mk` | `obs-up`, `obs-down`, `obs-logs` targets |

## Usage

```bash
make obs-up   # starts Prometheus (:9090), Grafana (:3000), cAdvisor
make obs-down
```

## Test plan

- [ ] `make lint` passes (validated in branch)
- [ ] `make secrets` generates `GRAFANA_ADMIN_PASSWORD` in `.env.local`
- [ ] `make obs-up` starts all three containers and they reach healthy state
- [ ] Grafana at `http://localhost:3000` shows the Docker Containers dashboard with data

---
_Generated by [Claude Code](https://claude.ai/code/session_01U49qzEw62jyM6aCRAPDHmS)_