### PR TITLE
feat: implement network isolation for compose services and k8s (#5)

### DIFF
--- a/cluster/helm-components.yaml
+++ b/cluster/helm-components.yaml
@@ -98,7 +98,8 @@ components:
     values_file: helm/minio/values.yaml
     wait_timeout: "5m"
     depends_on: []
-    pre_manifests: []
+    pre_manifests:
+      - helm/minio/networkpolicy.yaml
     port_forward:
       - service: minio-console
         local_port: 9001

--- a/compose/docker-compose.db.yaml
+++ b/compose/docker-compose.db.yaml
@@ -19,6 +19,8 @@ services:
       - "pipeline"
       - "query"
     container_name: postgres
+    networks:
+      - db
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -69,6 +71,8 @@ services:
   #       condition: service_completed_successfully
   postgres-init:
     image: postgres:${POSTGRES_VERSION:-16-alpine}
+    networks:
+      - db
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -102,3 +106,7 @@ services:
 
 volumes:
   postgres-data:
+
+networks:
+  db:
+    driver: bridge

--- a/compose/docker-compose.logging.yaml
+++ b/compose/docker-compose.logging.yaml
@@ -27,6 +27,9 @@ services:
       - logging
       # - pipeline  # logging is failing for airflow
     restart: unless-stopped
+    networks:
+      - logging
+      - storage
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -63,3 +66,9 @@ services:
 
 volumes:
   fluentd-buffer:
+
+networks:
+  logging:
+    driver: bridge
+  storage:
+    driver: bridge

--- a/compose/docker-compose.mock.yaml
+++ b/compose/docker-compose.mock.yaml
@@ -26,6 +26,9 @@ services:
     profiles: [mock]
     container_name: wiremock
     restart: unless-stopped
+    networks:
+      - mock
+      - proxy
 
     # WireMock flags:
     #   --verbose                  log every matched/unmatched request
@@ -64,3 +67,9 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+
+networks:
+  mock:
+    driver: bridge
+  proxy:
+    driver: bridge

--- a/compose/docker-compose.observability.yaml
+++ b/compose/docker-compose.observability.yaml
@@ -23,6 +23,8 @@ services:
     image: prom/prometheus:${PROMETHEUS_VERSION}
     profiles: [observability]
     restart: unless-stopped
+    networks:
+      - observability
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -57,6 +59,8 @@ services:
     image: grafana/grafana:${GRAFANA_VERSION}
     profiles: [observability]
     restart: unless-stopped
+    networks:
+      - observability
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -94,6 +98,8 @@ services:
     image: gcr.io/cadvisor/cadvisor:${CADVISOR_VERSION}
     profiles: [observability]
     restart: unless-stopped
+    networks:
+      - observability
     privileged: true
     volumes:
       - /:/rootfs:ro
@@ -118,3 +124,7 @@ services:
 volumes:
   prometheus-data:
   grafana-data:
+
+networks:
+  observability:
+    driver: bridge

--- a/compose/docker-compose.pipeline.yaml
+++ b/compose/docker-compose.pipeline.yaml
@@ -54,6 +54,9 @@ x-airflow-common: &airflow-common
     # AIRFLOW_CONN_AIRFLOW_API: "http://${AIRFLOW_ADMIN_USER}:${AIRFLOW_ADMIN_PASSWORD}@airflow-webserver:8080"   # Added logic within init 
     AIRFLOW_VAR_EXEC_ENV: compose
 
+  networks:
+    - pipeline
+    - db
   volumes:
     - ${PWD}/dags/dags:/opt/airflow/dags:ro
     - ${PWD}/compose/container/logs/airflow:/opt/airflow/logs:rw
@@ -147,6 +150,10 @@ services:
     <<: *airflow-common
     command: api-server
     container_name: airflow-api-server
+    networks:
+      - pipeline
+      - db
+      - proxy
     ports:
       - "${AIRFLOW_API_SERVER_PORT:-8080}:8080"
     depends_on:
@@ -181,3 +188,11 @@ services:
 
 volumes:
   plugins:
+
+networks:
+  pipeline:
+    driver: bridge
+  db:
+    driver: bridge
+  proxy:
+    driver: bridge

--- a/compose/docker-compose.proxy.yaml
+++ b/compose/docker-compose.proxy.yaml
@@ -29,6 +29,8 @@ services:
     image: nginx:${NGINX_IMAGE_TAG:-1.27-alpine}
     container_name: nginx
     profiles: [proxy]
+    networks:
+      - proxy
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -63,3 +65,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+networks:
+  proxy:
+    driver: bridge

--- a/compose/docker-compose.query.yaml
+++ b/compose/docker-compose.query.yaml
@@ -35,6 +35,11 @@ services:
     container_name: iceberg-rest
     profiles: [query]
     restart: unless-stopped
+    networks:
+      - db
+      - storage
+      - query
+      - proxy
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -91,6 +96,10 @@ services:
     container_name: trino
     profiles: [query]
     restart: unless-stopped
+    networks:
+      - query
+      - storage
+      - proxy
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -122,3 +131,13 @@ services:
       timeout: 5s
       retries: 10
       start_period: 30s
+
+networks:
+  db:
+    driver: bridge
+  storage:
+    driver: bridge
+  query:
+    driver: bridge
+  proxy:
+    driver: bridge

--- a/compose/docker-compose.storage.yaml
+++ b/compose/docker-compose.storage.yaml
@@ -11,6 +11,9 @@ services:
       - storage
       # - pipeline
     restart: unless-stopped
+    networks:
+      - storage
+      - proxy
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -51,6 +54,8 @@ services:
     profiles:
       - storage
     restart: no
+    networks:
+      - storage
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -78,3 +83,9 @@ services:
 
 volumes:
   minio-data:
+
+networks:
+  storage:
+    driver: bridge
+  proxy:
+    driver: bridge

--- a/helm/minio/networkpolicy.yaml
+++ b/helm/minio/networkpolicy.yaml
@@ -1,0 +1,39 @@
+# NetworkPolicy for the s3 (MinIO) namespace.
+# Allows ingress to MinIO only from the af (airflow) and misc (nginx) namespaces.
+# Intra-namespace traffic is unrestricted (minio ↔ minio-init/console).
+# All other ingress is denied by default.
+#
+# Applied by: make kube-secrets (via pre_manifests in helm-components.yaml)
+# Requires:   kind cluster running kindnet (default CNI, supports NetworkPolicy)
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: minio-allow-airflow-and-nginx
+  namespace: s3
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow intra-namespace traffic (minio ↔ minio console, init jobs)
+    - from:
+        - podSelector: {}
+    # Allow Airflow pods in the af namespace to reach MinIO on S3 API port
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: af
+      ports:
+        - protocol: TCP
+          port: 9000
+    # Allow nginx in misc namespace to reach MinIO console (9001) and S3 API (9000)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: misc
+      ports:
+        - protocol: TCP
+          port: 9000
+        - protocol: TCP
+          port: 9001

--- a/scripts/kube-secrets.sh
+++ b/scripts/kube-secrets.sh
@@ -55,6 +55,20 @@ for ns in db af misc s3; do
   log_info "  namespace/$ns (ensured)"
 done
 
+# ── Namespace-scoped NetworkPolicies ─────────────────────────────────────────
+# Applied here (not via pre_manifests) for components that may be disabled so
+# that the deny-by-default posture is in place whenever the namespace exists.
+log_step "Namespace NetworkPolicies"
+for policy in \
+  "${REPO_ROOT}/helm/postgres/networkpolicy.yaml" \
+  "${REPO_ROOT}/helm/airflow/networkpolicy.yaml" \
+  "${REPO_ROOT}/helm/wiremock/networkpolicy.yaml" \
+  "${REPO_ROOT}/helm/nginx/networkpolicy.yaml" \
+  "${REPO_ROOT}/helm/minio/networkpolicy.yaml"; do
+  kubectl apply -f "$policy"
+  log_ok "  Applied: ${policy#${REPO_ROOT}/}"
+done
+
 # ── ResourceQuota per namespace ───────────────────────────────────────────────
 # Prevents a single component from consuming all node resources.
 # Limits are sized for a single-node kind cluster with ~4 vCPU / 6 GB RAM.


### PR DESCRIPTION
## Summary

- Add named bridge networks to all 8 Docker Compose files so each service can only communicate with its legitimate peers; previously all services shared the default bridge network
- Introduce a shared `proxy` network for nginx to reach the services it reverse-proxies (airflow-api-server, iceberg-rest, trino, minio, wiremock) while keeping databases and internal services unreachable from the proxy layer
- Add `helm/minio/networkpolicy.yaml` restricting ingress to the `s3` namespace to Airflow (`af`) and nginx (`misc`) only, matching the existing pattern for postgres and airflow
- Register the MinIO NetworkPolicy in `cluster/helm-components.yaml` `pre_manifests` so it is applied before Helm install

## Network topology (Docker Compose)

| Network | Members |
|---------|---------|
| `db` | postgres, postgres-init, iceberg-rest, all airflow services |
| `storage` | minio, minio-init, iceberg-rest, fluentd |
| `query` | iceberg-rest, trino |
| `pipeline` | all airflow services |
| `proxy` | nginx, airflow-api-server, iceberg-rest, trino, minio, wiremock |
| `logging` | fluentd |
| `mock` | wiremock |
| `observability` | prometheus, grafana, cadvisor |

## Test plan

- [ ] `make lint` passes (validated locally with required env vars)
- [ ] `make query` starts iceberg-rest and trino; Trino can query Iceberg tables via MinIO
- [ ] `make pipeline` starts all Airflow services; scheduler reaches api-server and postgres
- [ ] `make proxy-up` starts nginx; all proxy routes resolve to their upstream services
- [ ] `make obs-up` starts prometheus, grafana, cadvisor in isolation
- [ ] `make kube-up` applies MinIO NetworkPolicy before Helm install (verify with `kubectl get networkpolicy -n s3`)

Closes #5

---
_Generated by [Claude Code](https://claude.ai/code/session_012746mokmm8o25dTMXA7TfX)_