### PR TITLE
feat: add HashiCorp Vault with Airflow 3 secrets backend integration

### DIFF
--- a/.env
+++ b/.env
@@ -38,6 +38,10 @@ AWS_REGION=us-east-1
 AIRFLOW_VAR_ENVIRONMENT=local
 AIRFLOW__WEBSERVER__BASE_URL=http://localhost/airflow
 
+# ── Vault ────────────────────────────────────────────────────
+VAULT_VERSION=1.17.2
+VAULT_PORT=8200
+
 # ── Observability ─────────────────────────────────────────────
 PROMETHEUS_VERSION=v2.53.2
 GRAFANA_VERSION=11.1.4

--- a/.env
+++ b/.env
@@ -35,6 +35,7 @@ MINIO_BUCKETS=airflow-logs,airflow-data,iceberg-warehouse
 AWS_REGION=us-east-1
 
 # ── Airflow ──────────────────────────────────────────────────
+AIRFLOW_VERSION=3.2.0
 AIRFLOW_VAR_ENVIRONMENT=local
 AIRFLOW__WEBSERVER__BASE_URL=http://localhost/airflow
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ compose/container/
 
 # ── Local secrets — never commit ─────────────────────────────
 .env.local
+.env.vault
 
 # ── OS artifacts ─────────────────────────────────────────────
 .DS_Store

--- a/compose/airflow/Dockerfile
+++ b/compose/airflow/Dockerfile
@@ -1,0 +1,5 @@
+ARG AIRFLOW_VERSION=3.2.0
+FROM apache/airflow:${AIRFLOW_VERSION}
+
+# Install providers baked-in so containers start instantly (no pip on every run).
+RUN pip install --no-cache-dir apache-airflow-providers-hashicorp

--- a/compose/docker-compose.db.yaml
+++ b/compose/docker-compose.db.yaml
@@ -38,7 +38,7 @@ services:
       POSTGRES_DB:       ${POSTGRES_DB:-airflow}
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ${BASE_DIR}/../config/postgres:/opt/init/sql:rw
+      - ${BASE_DIR}/../config/postgres:/opt/init/sql:ro
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     healthcheck:

--- a/compose/docker-compose.db.yaml
+++ b/compose/docker-compose.db.yaml
@@ -11,6 +11,12 @@
 #                    Safe to re-run — all statements are idempotent.
 # ============================================================
 
+x-base-security: &base-security
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+
 services:
   postgres:
     image: postgres:${POSTGRES_VERSION:-16-alpine}
@@ -22,10 +28,7 @@ services:
     networks:
       - db
     restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     cap_add:
       - CHOWN        # chown data directory to postgres user on first start
       - SETUID       # su-exec: drop from root to postgres OS user
@@ -71,12 +74,10 @@ services:
   #       condition: service_completed_successfully
   postgres-init:
     image: postgres:${POSTGRES_VERSION:-16-alpine}
+    container_name: postgres-init
     networks:
       - db
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     profiles:
       - "db"
       # pipeline profile intentionally excluded:
@@ -99,7 +100,7 @@ services:
     volumes:
       - ${BASE_DIR}/../config/postgres:/opt/init:ro
     # set -e aborts on the first failing script so errors are never silently swallowed.
-    entrypoint: 
+    entrypoint:
       - bash
       - -ec
       - /opt/init/setup.sh
@@ -110,3 +111,4 @@ volumes:
 networks:
   db:
     driver: bridge
+    internal: true  # postgres is internal-only; services reach it via db network

--- a/compose/docker-compose.logging.yaml
+++ b/compose/docker-compose.logging.yaml
@@ -23,9 +23,12 @@ services:
       context: ./fluentd
       dockerfile: Dockerfile
     image: fluentd-local:${FLUENTD_IMAGE_TAG:-1.0}  # bump FLUENTD_IMAGE_TAG in .env on Dockerfile changes
+    container_name: fluentd
     profiles:
       - logging
-      # - pipeline  # logging is failing for airflow
+      # pipeline excluded: start with `make up PROFILE=storage,logging,pipeline`
+      # to enable log shipping. fluentd-async (set in pipeline.yaml) means
+      # Airflow containers start fine even when fluentd is not running.
     restart: unless-stopped
     networks:
       - logging

--- a/compose/docker-compose.logging.yaml
+++ b/compose/docker-compose.logging.yaml
@@ -58,7 +58,7 @@ services:
       minio:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "sh", "-c", "echo '' | nc -w1 localhost 24224"]
+      test: ["CMD", "curl", "-sf", "http://localhost:9880/api/plugins.json"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/compose/docker-compose.observability.yaml
+++ b/compose/docker-compose.observability.yaml
@@ -18,17 +18,26 @@
 # Prometheus metrics; it is internal-only (no host port).
 # ============================================================
 
+# cAdvisor requires host cgroup/proc access so it cannot drop all capabilities.
+# Use x-no-privesc for cAdvisor; x-base-security for everything else.
+x-no-privesc: &no-privesc
+  security_opt:
+    - no-new-privileges:true
+
+x-base-security: &base-security
+  <<: *no-privesc
+  cap_drop:
+    - ALL
+
 services:
   prometheus:
     image: prom/prometheus:${PROMETHEUS_VERSION}
+    container_name: prometheus
     profiles: [observability]
     restart: unless-stopped
     networks:
       - observability
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
@@ -57,14 +66,12 @@ services:
 
   grafana:
     image: grafana/grafana:${GRAFANA_VERSION}
+    container_name: grafana
     profiles: [observability]
     restart: unless-stopped
     networks:
       - observability
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     depends_on:
       prometheus:
         condition: service_healthy
@@ -93,15 +100,16 @@ services:
           memory: 256M
 
   # cAdvisor exposes per-container CPU, memory, network, and filesystem
-  # metrics to Prometheus. Requires privileged mode to read cgroup data.
+  # metrics to Prometheus. Requires host volume mounts to read cgroup data;
+  # cannot use cap_drop:ALL (uses *no-privesc instead of *base-security).
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:${CADVISOR_VERSION}
+    container_name: cadvisor
     profiles: [observability]
     restart: unless-stopped
     networks:
       - observability
-    security_opt:
-      - no-new-privileges:true
+    <<: *no-privesc
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro

--- a/compose/docker-compose.observability.yaml
+++ b/compose/docker-compose.observability.yaml
@@ -100,7 +100,8 @@ services:
     restart: unless-stopped
     networks:
       - observability
-    privileged: true
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro

--- a/compose/docker-compose.pipeline.yaml
+++ b/compose/docker-compose.pipeline.yaml
@@ -67,8 +67,10 @@ x-airflow-common: &airflow-common
 
   # Vault backend is activated by .env.vault (created by `make pipeline-vault`,
   # removed by `make vault-down`). When the file is absent Airflow uses its DB.
+  # Path is relative to this compose file's directory (compose/), so ../ reaches
+  # the project root where vault.mk creates .env.vault.
   env_file:
-    - path: .env.vault
+    - path: ../.env.vault
       required: false
 
   networks:

--- a/compose/docker-compose.pipeline.yaml
+++ b/compose/docker-compose.pipeline.yaml
@@ -19,7 +19,12 @@
 
 # --------------- Airflow shared anchors ---------------------
 x-airflow-common: &airflow-common
-  image: apache/airflow:3.2.0
+  build:
+    context: ./airflow
+    dockerfile: Dockerfile
+    args:
+      AIRFLOW_VERSION: "3.2.0"
+  image: airflow-local:3.2.0
   restart: unless-stopped
   profiles: [pipeline]
   user: "${AIRFLOW_UID:-50000}:0"
@@ -54,18 +59,17 @@ x-airflow-common: &airflow-common
     # AIRFLOW_CONN_AIRFLOW_API: "http://${AIRFLOW_ADMIN_USER}:${AIRFLOW_ADMIN_PASSWORD}@airflow-webserver:8080"   # Added logic within init
     AIRFLOW_VAR_EXEC_ENV: compose
     # ── Vault secrets backend ─────────────────────────────────
-    # Active when `vault` profile is also running (make pipeline-vault).
-    # Airflow resolves connections/variables from Vault transparently;
-    # DAG code requires no changes — BaseHook.get_connection() and
-    # Variable.get() work as normal.
-    # If Vault is not running, lookups fall back to the Airflow DB.
     # VAULT_TOKEN is read by hvac (the Vault Python client) from env.
-    VAULT_TOKEN: ${VAULT_DEV_ROOT_TOKEN:-}
-    AIRFLOW__SECRETS__BACKEND: airflow.providers.hashicorp.secrets.vault.VaultBackend
-    AIRFLOW__SECRETS__BACKEND_KWARGS: '{"connections_path":"airflow/connections","variables_path":"airflow/variables","url":"http://vault:8200","auth_type":"token","kv_engine_version":2}'
-    # Installs the HashiCorp provider on container start (cached by pip after first run).
-    # Required for VaultBackend. Remove if not using Vault to speed up restarts.
-    _PIP_ADDITIONAL_REQUIREMENTS: apache-airflow-providers-hashicorp
+    # Uses the policy-scoped VAULT_AIRFLOW_TOKEN (not the root token).
+    # AIRFLOW__SECRETS__BACKEND* are injected via .env.vault (see below)
+    # so this block is a no-op when Vault is not running.
+    VAULT_TOKEN: ${VAULT_AIRFLOW_TOKEN:-}
+
+  # Vault backend is activated by .env.vault (created by `make pipeline-vault`,
+  # removed by `make vault-down`). When the file is absent Airflow uses its DB.
+  env_file:
+    - path: .env.vault
+      required: false
 
   networks:
     - pipeline

--- a/compose/docker-compose.pipeline.yaml
+++ b/compose/docker-compose.pipeline.yaml
@@ -109,6 +109,7 @@ services:
   # -- One-shot: DB migration + admin user creation ----------
   airflow-init:
     <<: *airflow-common
+    container_name: airflow-init
     restart: no
     command:
       - bash
@@ -150,6 +151,7 @@ services:
   # -- Scheduler: triggers DAG runs + executes tasks locally -
   airflow-scheduler:
     <<: *airflow-common
+    container_name: airflow-scheduler
     command: scheduler
     depends_on:
       <<: *airflow-common-depends
@@ -183,6 +185,7 @@ services:
 
   airflow-dag-processor:
     <<: *airflow-common
+    container_name: airflow-dag-processor
     command: dag-processor
     healthcheck:
       test: ["CMD-SHELL", 'airflow jobs check --job-type DagProcessorJob --hostname "$${HOSTNAME}"']
@@ -194,6 +197,7 @@ services:
 
   airflow-triggerer:
     <<: *airflow-common
+    container_name: airflow-triggerer
     command: triggerer
     healthcheck:
       test: ["CMD-SHELL", 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
@@ -211,5 +215,6 @@ networks:
     driver: bridge
   db:
     driver: bridge
+    internal: true  # postgres is internal-only; matches db.yaml declaration
   proxy:
     driver: bridge

--- a/compose/docker-compose.pipeline.yaml
+++ b/compose/docker-compose.pipeline.yaml
@@ -23,8 +23,8 @@ x-airflow-common: &airflow-common
     context: ./airflow
     dockerfile: Dockerfile
     args:
-      AIRFLOW_VERSION: "3.2.0"
-  image: airflow-local:3.2.0
+      AIRFLOW_VERSION: "${AIRFLOW_VERSION:-3.2.0}"
+  image: airflow-local:${AIRFLOW_VERSION:-3.2.0}
   restart: unless-stopped
   profiles: [pipeline]
   user: "${AIRFLOW_UID:-50000}:0"

--- a/compose/docker-compose.pipeline.yaml
+++ b/compose/docker-compose.pipeline.yaml
@@ -51,8 +51,21 @@ x-airflow-common: &airflow-common
     AIRFLOW__LOGGING__LOGGING_LEVEL: INFO
     AIRFLOW_VAR_ENVIRONMENT: local
     # Creating connection
-    # AIRFLOW_CONN_AIRFLOW_API: "http://${AIRFLOW_ADMIN_USER}:${AIRFLOW_ADMIN_PASSWORD}@airflow-webserver:8080"   # Added logic within init 
+    # AIRFLOW_CONN_AIRFLOW_API: "http://${AIRFLOW_ADMIN_USER}:${AIRFLOW_ADMIN_PASSWORD}@airflow-webserver:8080"   # Added logic within init
     AIRFLOW_VAR_EXEC_ENV: compose
+    # ── Vault secrets backend ─────────────────────────────────
+    # Active when `vault` profile is also running (make pipeline-vault).
+    # Airflow resolves connections/variables from Vault transparently;
+    # DAG code requires no changes — BaseHook.get_connection() and
+    # Variable.get() work as normal.
+    # If Vault is not running, lookups fall back to the Airflow DB.
+    # VAULT_TOKEN is read by hvac (the Vault Python client) from env.
+    VAULT_TOKEN: ${VAULT_DEV_ROOT_TOKEN:-}
+    AIRFLOW__SECRETS__BACKEND: airflow.providers.hashicorp.secrets.vault.VaultBackend
+    AIRFLOW__SECRETS__BACKEND_KWARGS: '{"connections_path":"airflow/connections","variables_path":"airflow/variables","url":"http://vault:8200","auth_type":"token","kv_engine_version":2}'
+    # Installs the HashiCorp provider on container start (cached by pip after first run).
+    # Required for VaultBackend. Remove if not using Vault to speed up restarts.
+    _PIP_ADDITIONAL_REQUIREMENTS: apache-airflow-providers-hashicorp
 
   networks:
     - pipeline

--- a/compose/docker-compose.proxy.yaml
+++ b/compose/docker-compose.proxy.yaml
@@ -41,7 +41,6 @@ services:
       - "${NGINX_PORT:-80}:80"
     volumes:
       - ${BASE_DIR}/../compose/nginx/:/etc/nginx/:ro
-      - ${BASE_DIR}/../compose/nginx/conf.d:/etc/nginx/conf.d:ro
     deploy:
       resources:
         limits:

--- a/compose/docker-compose.query.yaml
+++ b/compose/docker-compose.query.yaml
@@ -67,9 +67,9 @@ services:
       # RESTCatalogServer logs the full properties map (incl. passwords)
       # at INFO on startup. This mounts a custom logback.xml that sets
       # that logger to WARN, suppressing the credential line only.
-      # JAVA_TOOL_OPTIONS: "-Dlogback.configurationFile=/logback.xml"
-    # volumes:
-    #   - ./iceberg-rest/logback.xml:/opt/logback.xml:ro
+      JAVA_TOOL_OPTIONS: "-Dlogback.configurationFile=/opt/logback.xml"
+    volumes:
+      - ./iceberg-rest/logback.xml:/opt/logback.xml:ro
     deploy:
       resources:
         limits:

--- a/compose/docker-compose.query.yaml
+++ b/compose/docker-compose.query.yaml
@@ -21,6 +21,12 @@
 #   trino         — Distributed SQL engine over Iceberg tables via REST catalog
 # ============================================================
 
+x-base-security: &base-security
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+
 services:
 
   # ── Iceberg REST Catalog ──────────────────────────────────
@@ -40,10 +46,7 @@ services:
       - storage
       - query
       - proxy
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     depends_on:
       postgres-init:                        # iceberg DB must exist first
         condition: service_completed_successfully
@@ -100,10 +103,7 @@ services:
       - query
       - storage
       - proxy
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     depends_on:
       iceberg-rest:
         condition: service_healthy
@@ -135,6 +135,7 @@ services:
 networks:
   db:
     driver: bridge
+    internal: true  # postgres is internal-only; matches db.yaml declaration
   storage:
     driver: bridge
   query:

--- a/compose/docker-compose.storage.yaml
+++ b/compose/docker-compose.storage.yaml
@@ -4,20 +4,26 @@
 #   docker compose --profile storage up
 # ============================================================
 
+x-base-security: &base-security
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+
 services:
   minio:
     image: minio/minio:${MINIO_VERSION:?MINIO_VERSION must be set in .env}
     profiles:
       - storage
-      # - pipeline
+      # pipeline intentionally excluded: Airflow does not require MinIO for
+      # basic DAG execution. Add --profile storage alongside --profile pipeline
+      # when DAGs write to S3, or use `make pipeline-full` to start both together.
+    container_name: minio
     restart: unless-stopped
     networks:
       - storage
       - proxy
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set in .env.local}
@@ -53,13 +59,11 @@ services:
     image: minio/mc:${MC_VERSION}
     profiles:
       - storage
+    container_name: minio-init
     restart: no
     networks:
       - storage
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     depends_on:
       minio:
         condition: service_healthy
@@ -80,6 +84,14 @@ services:
         done;
         echo 'All buckets ready.';
       "
+    deploy:
+      resources:
+        limits:
+          cpus: "0.2"
+          memory: 64M
+        reservations:
+          cpus: "0.05"
+          memory: 32M
 
 volumes:
   minio-data:

--- a/compose/docker-compose.vault.yaml
+++ b/compose/docker-compose.vault.yaml
@@ -27,6 +27,12 @@
 #   make pipeline-vault    — start Airflow + Vault together
 # ============================================================
 
+x-base-security: &base-security
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+
 services:
 
   # -- Vault server (dev mode) --------------------------------
@@ -42,12 +48,14 @@ services:
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_DEV_ROOT_TOKEN:?VAULT_DEV_ROOT_TOKEN must be set in .env.local}
       VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+    # cap_drop:ALL omitted intentionally: Vault dev mode sets file capabilities
+    # (IPC_LOCK) internally; dropping all caps before that prevents startup.
+    security_opt:
+      - no-new-privileges:true
     cap_add:
       - IPC_LOCK  # prevents Vault memory pages from being swapped to disk
     command: server -dev
     restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
     healthcheck:
       test: ["CMD", "vault", "status", "-address=http://127.0.0.1:8200"]
       interval: 10s
@@ -77,16 +85,14 @@ services:
   vault-init:
     image: hashicorp/vault:${VAULT_VERSION:-1.17.2}
     profiles: [vault]
+    container_name: vault-init
     networks:
       - vault
     depends_on:
       vault:
         condition: service_healthy
     restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
+    <<: *base-security
     environment:
       VAULT_ADDR: "http://vault:8200"
       VAULT_TOKEN: ${VAULT_DEV_ROOT_TOKEN:?VAULT_DEV_ROOT_TOKEN must be set in .env.local}
@@ -109,5 +115,6 @@ services:
 networks:
   vault:
     driver: bridge
+    internal: true  # vault and vault-init communicate only with each other
   pipeline:
     driver: bridge

--- a/compose/docker-compose.vault.yaml
+++ b/compose/docker-compose.vault.yaml
@@ -1,0 +1,122 @@
+# ============================================================
+# docker-compose.vault.yaml
+# HashiCorp Vault — local secrets manager for development
+#
+# Vault runs in -dev mode:
+#   - auto-initialized and unsealed on startup
+#   - in-memory backend (secrets lost on container restart)
+#   - KV v2 engine pre-mounted at secret/ by Vault itself
+#   - root token fixed via VAULT_DEV_ROOT_TOKEN in .env.local
+#
+# Airflow integration:
+#   Vault joins the `pipeline` network so Airflow containers
+#   can reach it as vault:8200. The VaultBackend is configured
+#   in docker-compose.pipeline.yaml via AIRFLOW__SECRETS__BACKEND.
+#   Connections and variables stored in Vault are resolved
+#   transparently — DAG code requires no changes.
+#
+#   Vault paths used by Airflow:
+#     secret/airflow/connections/<conn_id>
+#     secret/airflow/variables/<var_name>
+#
+# Profiles:
+#   vault — vault server + vault-init
+#
+# Typical usage:
+#   make vault-up          — start Vault alone
+#   make pipeline-vault    — start Airflow + Vault together
+# ============================================================
+
+services:
+
+  # -- Vault server (dev mode) --------------------------------
+  vault:
+    image: hashicorp/vault:${VAULT_VERSION:-1.17.2}
+    profiles: [vault]
+    container_name: vault
+    networks:
+      - vault
+      - pipeline  # Airflow containers reach Vault as vault:8200
+    ports:
+      - "${VAULT_PORT:-8200}:8200"
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_DEV_ROOT_TOKEN:?VAULT_DEV_ROOT_TOKEN must be set in .env.local}
+      VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+    cap_add:
+      - IPC_LOCK  # prevents Vault memory pages from being swapped to disk
+    cap_drop:
+      - ALL
+    command: server -dev
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "vault", "status", "-address=http://127.0.0.1:8200"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
+
+  # -- One-shot: seed example secrets in Vault ---------------
+  # Writes the KV paths that Airflow's VaultBackend resolves:
+  #   secret/airflow/connections/<conn_id>
+  #   secret/airflow/variables/<var_name>
+  # Dev mode pre-enables KV v2 at secret/ so no explicit enable needed.
+  vault-init:
+    image: hashicorp/vault:${VAULT_VERSION:-1.17.2}
+    profiles: [vault]
+    networks:
+      - vault
+    depends_on:
+      vault:
+        condition: service_healthy
+    restart: no
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    environment:
+      VAULT_ADDR: "http://vault:8200"
+      VAULT_TOKEN: ${VAULT_DEV_ROOT_TOKEN:?VAULT_DEV_ROOT_TOKEN must be set in .env.local}
+      POSTGRES_USER: ${POSTGRES_USER:-airflow}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+      POSTGRES_DB: ${POSTGRES_DB:-airflow}
+    entrypoint:
+      - sh
+      - -ec
+      - |
+          echo "Seeding Airflow connection: postgres_default..."
+          vault kv put secret/airflow/connections/postgres_default \
+            conn_type=postgres \
+            host=postgres \
+            schema="${POSTGRES_DB}" \
+            login="${POSTGRES_USER}" \
+            password="${POSTGRES_PASSWORD}" \
+            port=5432
+
+          echo "Seeding Airflow variable: environment..."
+          vault kv put secret/airflow/variables/environment value=local
+
+          echo "Vault secrets initialized."
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 64M
+        reservations:
+          cpus: "0.1"
+          memory: 32M
+
+networks:
+  vault:
+    driver: bridge
+  pipeline:
+    driver: bridge

--- a/compose/docker-compose.vault.yaml
+++ b/compose/docker-compose.vault.yaml
@@ -44,8 +44,6 @@ services:
       VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
     cap_add:
       - IPC_LOCK  # prevents Vault memory pages from being swapped to disk
-    cap_drop:
-      - ALL
     command: server -dev
     restart: unless-stopped
     security_opt:

--- a/compose/docker-compose.vault.yaml
+++ b/compose/docker-compose.vault.yaml
@@ -63,11 +63,17 @@ services:
           cpus: "0.1"
           memory: 64M
 
-  # -- One-shot: seed example secrets in Vault ---------------
-  # Writes the KV paths that Airflow's VaultBackend resolves:
-  #   secret/airflow/connections/<conn_id>
-  #   secret/airflow/variables/<var_name>
-  # Dev mode pre-enables KV v2 at secret/ so no explicit enable needed.
+  # -- Sidecar: seed policies, scoped token, and example secrets -----------
+  # Runs as a long-lived sidecar (restart: unless-stopped) alongside vault.
+  # Dev mode uses an in-memory backend; vault-init.sh re-seeds everything
+  # after each vault restart so the Airflow token and secrets are always valid.
+  #
+  # Seeded paths (KV v2):
+  #   secret/airflow/connections/postgres_default
+  #   secret/airflow/variables/environment
+  #
+  # Created policy: airflow-ro (read-only to secret/airflow/*)
+  # Created token:  VAULT_AIRFLOW_TOKEN (policy-scoped; never the root token)
   vault-init:
     image: hashicorp/vault:${VAULT_VERSION:-1.17.2}
     profiles: [vault]
@@ -76,7 +82,7 @@ services:
     depends_on:
       vault:
         condition: service_healthy
-    restart: no
+    restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -84,33 +90,20 @@ services:
     environment:
       VAULT_ADDR: "http://vault:8200"
       VAULT_TOKEN: ${VAULT_DEV_ROOT_TOKEN:?VAULT_DEV_ROOT_TOKEN must be set in .env.local}
+      VAULT_AIRFLOW_TOKEN: ${VAULT_AIRFLOW_TOKEN:?VAULT_AIRFLOW_TOKEN must be set in .env.local}
       POSTGRES_USER: ${POSTGRES_USER:-airflow}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env.local}
       POSTGRES_DB: ${POSTGRES_DB:-airflow}
-    entrypoint:
-      - sh
-      - -ec
-      - |
-          echo "Seeding Airflow connection: postgres_default..."
-          vault kv put secret/airflow/connections/postgres_default \
-            conn_type=postgres \
-            host=postgres \
-            schema="${POSTGRES_DB}" \
-            login="${POSTGRES_USER}" \
-            password="${POSTGRES_PASSWORD}" \
-            port=5432
-
-          echo "Seeding Airflow variable: environment..."
-          vault kv put secret/airflow/variables/environment value=local
-
-          echo "Vault secrets initialized."
+    volumes:
+      - ./vault/vault-init.sh:/vault-init.sh:ro
+    entrypoint: ["sh", "/vault-init.sh"]
     deploy:
       resources:
         limits:
-          cpus: "0.25"
+          cpus: "0.1"
           memory: 64M
         reservations:
-          cpus: "0.1"
+          cpus: "0.05"
           memory: 32M
 
 networks:

--- a/compose/fluentd/Dockerfile
+++ b/compose/fluentd/Dockerfile
@@ -8,10 +8,13 @@ FROM fluent/fluentd:v1.19-2
 
 USER root
 
-RUN gem install \
-      fluent-plugin-s3 \
-      fluent-plugin-multi-format-parser \
-      --no-document \
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/* \
+  && gem install \
+       fluent-plugin-s3 \
+       fluent-plugin-multi-format-parser \
+       --no-document \
   # Pre-create buffer directory owned by fluent user so Docker
   # named volume mount doesn't land as root-owned.
   && mkdir -p /fluentd/buffer \

--- a/compose/fluentd/fluent.conf
+++ b/compose/fluentd/fluent.conf
@@ -23,6 +23,16 @@
   bind     0.0.0.0
 </source>
 
+# Exposes plugin metrics at http://localhost:9880/api/plugins.json
+# Used by the Docker Compose healthcheck (nc on 24224 can't distinguish
+# "port open" from "server ready to accept logs").
+<source>
+  @type    monitor_agent
+  @id      in_monitor_agent
+  bind     0.0.0.0
+  port     9880
+</source>
+
 # ── Filters ──────────────────────────────────────────────────
 
 # 1. Parse the inner `log` field as JSON (Airflow 3 task logs are

--- a/compose/iceberg-rest/logback.xml
+++ b/compose/iceberg-rest/logback.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <!-- ── Console appender ──────────────────────────────────── -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%logger{36}] - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- ── Suppress credential-leaking startup log ───────────── -->
+  <!-- RESTCatalogServer logs the full properties map (incl. passwords) -->
+  <!-- at INFO on startup. WARN suppresses that line only.             -->
+  <logger name="org.apache.iceberg.rest.RESTCatalogServer" level="WARN" />
+
+  <!-- ── Root logger ───────────────────────────────────────── -->
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
+  </root>
+
+</configuration>

--- a/compose/vault/vault-init.sh
+++ b/compose/vault/vault-init.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# vault-init.sh — watch-and-seed sidecar for the vault dev-mode container.
+#
+# Dev mode uses an in-memory backend: all data is lost on every vault restart.
+# This script runs as a sidecar (restart: unless-stopped) and re-seeds policies,
+# the Airflow scoped token, and example secrets each time vault comes back up.
+#
+# Required env vars (set in docker-compose.vault.yaml):
+#   VAULT_ADDR           — e.g. http://vault:8200
+#   VAULT_TOKEN          — root token (VAULT_DEV_ROOT_TOKEN) for seeding only
+#   VAULT_AIRFLOW_TOKEN  — hex token ID to create for Airflow's VaultBackend
+#   POSTGRES_USER        — seeded into connections/postgres_default
+#   POSTGRES_PASSWORD    — seeded into connections/postgres_default
+#   POSTGRES_DB          — seeded into connections/postgres_default
+set -eu
+
+POLL_INTERVAL=30   # seconds between health polls after seeding
+
+wait_for_vault() {
+  echo "[vault-init] Waiting for Vault to be ready..."
+  until vault status -address="${VAULT_ADDR}" >/dev/null 2>&1; do
+    sleep 2
+  done
+  echo "[vault-init] Vault is ready."
+}
+
+seed_vault() {
+  echo "[vault-init] Writing airflow-ro policy..."
+  vault policy write airflow-ro - <<POLICY
+path "secret/data/airflow/*" {
+  capabilities = ["read", "list"]
+}
+path "secret/metadata/airflow/*" {
+  capabilities = ["list"]
+}
+POLICY
+
+  echo "[vault-init] Creating scoped Airflow token (id=${VAULT_AIRFLOW_TOKEN:0:8}...)..."
+  vault token create \
+    -id="${VAULT_AIRFLOW_TOKEN}" \
+    -policy=airflow-ro \
+    -no-default-policy \
+    -period=72h \
+    -display-name=airflow-ro \
+    >/dev/null
+
+  echo "[vault-init] Seeding connection: postgres_default..."
+  vault kv put secret/airflow/connections/postgres_default \
+    conn_type=postgres \
+    host=postgres \
+    schema="${POSTGRES_DB}" \
+    login="${POSTGRES_USER}" \
+    password="${POSTGRES_PASSWORD}" \
+    port=5432
+
+  echo "[vault-init] Seeding variable: environment..."
+  vault kv put secret/airflow/variables/environment value=local
+
+  echo "[vault-init] Vault seeding complete."
+}
+
+main() {
+  wait_for_vault
+  seed_vault
+
+  # Poll: detect vault restart (dev mode wipes all state on restart) and re-seed.
+  while true; do
+    sleep "${POLL_INTERVAL}"
+    if ! vault status -address="${VAULT_ADDR}" >/dev/null 2>&1; then
+      echo "[vault-init] Vault became unavailable — waiting for restart..."
+      wait_for_vault
+      seed_vault
+    fi
+  done
+}
+
+main

--- a/compose/vault/vault-init.sh
+++ b/compose/vault/vault-init.sh
@@ -35,14 +35,23 @@ path "secret/metadata/airflow/*" {
 }
 POLICY
 
-  echo "[vault-init] Creating scoped Airflow token (id=${VAULT_AIRFLOW_TOKEN:0:8}...)..."
-  vault token create \
-    -id="${VAULT_AIRFLOW_TOKEN}" \
-    -policy=airflow-ro \
-    -no-default-policy \
-    -period=72h \
-    -display-name=airflow-ro \
-    >/dev/null
+  # POSIX-compatible prefix (${var:0:8} is bash-only; busybox sh rejects it).
+  TOKEN_PREFIX=$(printf '%s' "${VAULT_AIRFLOW_TOKEN}" | cut -c1-8)
+  echo "[vault-init] Creating scoped Airflow token (id=${TOKEN_PREFIX}...)..."
+  # Idempotent: skip creation if the token already exists.
+  # vault-init restarts while Vault is still live would otherwise fail here
+  # and crash-loop because set -eu aborts on non-zero exit.
+  if ! vault token lookup "${VAULT_AIRFLOW_TOKEN}" >/dev/null 2>&1; then
+    vault token create \
+      -id="${VAULT_AIRFLOW_TOKEN}" \
+      -policy=airflow-ro \
+      -no-default-policy \
+      -period=72h \
+      -display-name=airflow-ro \
+      >/dev/null
+  else
+    echo "[vault-init] Token already exists — skipping create."
+  fi
 
   echo "[vault-init] Seeding connection: postgres_default..."
   vault kv put secret/airflow/connections/postgres_default \
@@ -64,12 +73,16 @@ main() {
   seed_vault
 
   # Poll: detect vault restart (dev mode wipes all state on restart) and re-seed.
+  # Also renew the scoped token each cycle so it doesn't expire after -period=72h
+  # on long-running stacks where Vault never restarts.
   while true; do
     sleep "${POLL_INTERVAL}"
     if ! vault status -address="${VAULT_ADDR}" >/dev/null 2>&1; then
       echo "[vault-init] Vault became unavailable — waiting for restart..."
       wait_for_vault
       seed_vault
+    else
+      vault token renew "${VAULT_AIRFLOW_TOKEN}" >/dev/null 2>&1 || true
     fi
   done
 }

--- a/compose/vault/vault-init.sh
+++ b/compose/vault/vault-init.sh
@@ -33,6 +33,12 @@ path "secret/data/airflow/*" {
 path "secret/metadata/airflow/*" {
   capabilities = ["list"]
 }
+# hvac calls /auth/token/lookup-self to verify authentication before every
+# request. Without this the VaultBackend raises "Vault Authentication Error!"
+# even though the token can read secrets.
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}
 POLICY
 
   # POSIX-compatible prefix (${var:0:8} is bash-only; busybox sh rejects it).

--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -113,8 +113,15 @@ secrets:
     length: 16
 
   # ── Vault ──────────────────────────────────────────────────
-  # Dev-mode root token — also used by Airflow's VaultBackend.
+  # Dev-mode root token — used ONLY by vault-init to seed policies/secrets.
+  # Airflow never sees this token; it uses VAULT_AIRFLOW_TOKEN instead.
   # In dev mode Vault is NOT persistent; rotate freely.
   - key:    VAULT_DEV_ROOT_TOKEN
+    method: random_hex
+    length: 32
+
+  # Policy-scoped token for Airflow's VaultBackend (read-only to secret/airflow/*).
+  # vault-init creates this token with exactly this ID every time Vault starts.
+  - key:    VAULT_AIRFLOW_TOKEN
     method: random_hex
     length: 32

--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -111,3 +111,10 @@ secrets:
   - key:    GRAFANA_ADMIN_PASSWORD
     method: random_hex
     length: 16
+
+  # ── Vault ──────────────────────────────────────────────────
+  # Dev-mode root token — also used by Airflow's VaultBackend.
+  # In dev mode Vault is NOT persistent; rotate freely.
+  - key:    VAULT_DEV_ROOT_TOKEN
+    method: random_hex
+    length: 32

--- a/helm/airflow/values.yaml
+++ b/helm/airflow/values.yaml
@@ -140,11 +140,15 @@ dagProcessor:
       memory: 256Mi
   waitForMigrations:
     enabled: true
+  # ── Probe tuning (same rationale as triggerer above) ──────────
+  # `airflow jobs check --job-type DagProcessorJob` can take 20-30s on a
+  # resource-constrained kind node.  timeoutSeconds must exceed command
+  # wall-time; periodSeconds must be comfortably larger so probes don't overlap.
   livenessProbe:
-    initialDelaySeconds: 90
-    timeoutSeconds: 60
-    periodSeconds: 90
-    failureThreshold: 5
+    initialDelaySeconds: 90   # wait for DB migrations + process startup
+    timeoutSeconds: 60        # command budget; kubelet kills after this
+    periodSeconds: 90         # gap between probe attempts
+    failureThreshold: 5       # ~7.5 min of grace before pod is restarted
 
 # ── Scheduler ─────────────────────────────────────────────────
 scheduler:

--- a/makefile
+++ b/makefile
@@ -29,6 +29,7 @@ include scripts/make/ollama.mk
 include scripts/make/proxy.mk
 include scripts/make/security.mk
 include scripts/make/observability.mk
+include scripts/make/vault.mk
 
 # Export so scripts can inherit without re-reading
 export KIND_CLUSTER_NAME := $(CLUSTER_NAME)

--- a/scripts/make/compose.mk
+++ b/scripts/make/compose.mk
@@ -33,7 +33,7 @@ DC := docker compose $(ENV_FILE_FLAGS) $(PROFILE_FLAGS) \
       $(foreach f,$(COMPOSE_FILE_LIST),-f $(f))
 
 .PHONY: compose-up compose-down build restart logs shell ps clean prune lint \
-        sync dagcheck airflow-dirs build-query query pipeline
+        sync dagcheck airflow-dirs build-query build-pipeline query pipeline
 
 # =============================================================================
 # Core lifecycle
@@ -125,7 +125,20 @@ query: .env build-query ## Start query engine stack (Trino + Iceberg REST + Post
 	@echo "   Postgres      → localhost:$${POSTGRES_PORT:-5432} (dev only)"
 	@echo ""
 
-pipeline: .env airflow-dirs ## Start pipeline stack (Airflow + Postgres)
+build-pipeline: ## Build custom Airflow image with baked-in providers (skips if already present)
+	@AIRFLOW_VERSION=3.2.0; \
+	if docker image inspect airflow-local:$${AIRFLOW_VERSION} >/dev/null 2>&1; then \
+	  echo "✅ airflow-local:$${AIRFLOW_VERSION} already exists — skipping build."; \
+	else \
+	  echo "🔨 Building airflow-local:$${AIRFLOW_VERSION}..."; \
+	  docker build \
+	    --build-arg AIRFLOW_VERSION=$${AIRFLOW_VERSION} \
+	    --tag airflow-local:$${AIRFLOW_VERSION} \
+	    compose/airflow/; \
+	  echo "✅ airflow-local:$${AIRFLOW_VERSION} built"; \
+	fi
+
+pipeline: .env build-pipeline airflow-dirs ## Start pipeline stack (Airflow + Postgres)
 	@echo "🔍 Starting pipeline stack..."
 	docker compose $(ENV_FILE_FLAGS) \
 		--profile pipeline \

--- a/scripts/make/compose.mk
+++ b/scripts/make/compose.mk
@@ -12,9 +12,12 @@
 #   make shell SERVICE=postgres
 # =============================================================================
 
-# ── Read ICEBERG_REST_VERSION from .env (no -include, avoids .env remake loop) ─
+# ── Read versions from .env (no -include, avoids .env remake loop) ──────────
 ICEBERG_REST_VERSION := $(strip $(shell grep -s '^ICEBERG_REST_VERSION=' .env | cut -d= -f2))
 ICEBERG_REST_VERSION := $(if $(ICEBERG_REST_VERSION),$(ICEBERG_REST_VERSION),0.10.0)
+
+AIRFLOW_VERSION := $(strip $(shell grep -s '^AIRFLOW_VERSION=' .env | cut -d= -f2))
+AIRFLOW_VERSION := $(if $(AIRFLOW_VERSION),$(AIRFLOW_VERSION),3.2.0)
 
 # ── Env files ────────────────────────────────────────────────────────────────
 # .env holds non-secret defaults; .env.local holds secrets and local overrides.
@@ -126,16 +129,15 @@ query: .env build-query ## Start query engine stack (Trino + Iceberg REST + Post
 	@echo ""
 
 build-pipeline: ## Build custom Airflow image with baked-in providers (skips if already present)
-	@AIRFLOW_VERSION=3.2.0; \
-	if docker image inspect airflow-local:$${AIRFLOW_VERSION} >/dev/null 2>&1; then \
-	  echo "✅ airflow-local:$${AIRFLOW_VERSION} already exists — skipping build."; \
+	@if docker image inspect airflow-local:$(AIRFLOW_VERSION) >/dev/null 2>&1; then \
+	  echo "✅ airflow-local:$(AIRFLOW_VERSION) already exists — skipping build."; \
 	else \
-	  echo "🔨 Building airflow-local:$${AIRFLOW_VERSION}..."; \
+	  echo "🔨 Building airflow-local:$(AIRFLOW_VERSION)..."; \
 	  docker build \
-	    --build-arg AIRFLOW_VERSION=$${AIRFLOW_VERSION} \
-	    --tag airflow-local:$${AIRFLOW_VERSION} \
+	    --build-arg AIRFLOW_VERSION=$(AIRFLOW_VERSION) \
+	    --tag airflow-local:$(AIRFLOW_VERSION) \
 	    compose/airflow/; \
-	  echo "✅ airflow-local:$${AIRFLOW_VERSION} built"; \
+	  echo "✅ airflow-local:$(AIRFLOW_VERSION) built"; \
 	fi
 
 pipeline: .env build-pipeline airflow-dirs ## Start pipeline stack (Airflow + Postgres)

--- a/scripts/make/compose.mk
+++ b/scripts/make/compose.mk
@@ -33,7 +33,7 @@ DC := docker compose $(ENV_FILE_FLAGS) $(PROFILE_FLAGS) \
       $(foreach f,$(COMPOSE_FILE_LIST),-f $(f))
 
 .PHONY: compose-up compose-down build restart logs shell ps clean prune lint \
-        sync dagcheck airflow-dirs build-query build-pipeline query pipeline
+        sync dagcheck airflow-dirs build-query build-pipeline query pipeline pipeline-full
 
 # =============================================================================
 # Core lifecycle
@@ -147,5 +147,19 @@ pipeline: .env build-pipeline airflow-dirs ## Start pipeline stack (Airflow + Po
 	@echo ""
 	@echo "🚀 Pipeline stack is up:"
 	@echo "   Airflow UI    → http://localhost:$${AIRFLOW_API_SERVER_PORT:-8081}"
+	@echo "   Postgres      → localhost:$${POSTGRES_PORT:-5432} (dev only)"
+	@echo ""
+
+pipeline-full: .env build-pipeline airflow-dirs ## Start pipeline stack + MinIO (for DAGs that write to S3)
+	@echo "🔍 Starting full pipeline stack (Airflow + MinIO + Postgres)..."
+	docker compose $(ENV_FILE_FLAGS) \
+		--profile pipeline --profile storage \
+		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
+		up -d --remove-orphans
+	@echo ""
+	@echo "🚀 Full pipeline stack is up:"
+	@echo "   Airflow UI    → http://localhost:$${AIRFLOW_API_SERVER_PORT:-8081}"
+	@echo "   MinIO Console → http://localhost:$${MINIO_CONSOLE_PORT:-9001}"
+	@echo "   MinIO API     → localhost:$${MINIO_API_PORT:-9000}"
 	@echo "   Postgres      → localhost:$${POSTGRES_PORT:-5432} (dev only)"
 	@echo ""

--- a/scripts/make/vault.mk
+++ b/scripts/make/vault.mk
@@ -13,7 +13,7 @@ vault-up: .env ## Start Vault server and seed example secrets
 	@echo ""
 	@echo "Vault is up:"
 	@echo "   UI / API  → http://localhost:$${VAULT_PORT:-8200}"
-	@echo "   Token     → $$(grep VAULT_DEV_ROOT_TOKEN .env.local | cut -d= -f2)"
+	@echo "   Token     → $$(grep -E '^VAULT_DEV_ROOT_TOKEN=' .env.local | cut -d= -f2-)"
 	@echo ""
 
 vault-down: ## Stop Vault and remove .env.vault so Airflow stops using VaultBackend
@@ -22,7 +22,9 @@ vault-down: ## Stop Vault and remove .env.vault so Airflow stops using VaultBack
 		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
 		down
 	@rm -f .env.vault
-	@echo "  🗑  .env.vault removed — Airflow will use DB secrets on next restart"
+	@echo "  🗑  .env.vault removed."
+	@echo "  ⚠️   Running Airflow containers still have VaultBackend active until restarted."
+	@echo "       Run 'make pipeline' to restart Airflow without Vault."
 
 # Creates .env.vault which activates VaultBackend inside Airflow containers.
 # The file is git-ignored and absent by default so `make pipeline` never touches Vault.

--- a/scripts/make/vault.mk
+++ b/scripts/make/vault.mk
@@ -13,16 +13,27 @@ vault-up: .env ## Start Vault server and seed example secrets
 	@echo ""
 	@echo "Vault is up:"
 	@echo "   UI / API  → http://localhost:$${VAULT_PORT:-8200}"
-	@echo "   Token     → \$$(grep VAULT_DEV_ROOT_TOKEN .env.local | cut -d= -f2)"
+	@echo "   Token     → $$(grep VAULT_DEV_ROOT_TOKEN .env.local | cut -d= -f2)"
 	@echo ""
 
-vault-down: ## Stop Vault
+vault-down: ## Stop Vault and remove .env.vault so Airflow stops using VaultBackend
 	docker compose $(ENV_FILE_FLAGS) \
 		--profile vault \
 		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
 		down
+	@rm -f .env.vault
+	@echo "  🗑  .env.vault removed — Airflow will use DB secrets on next restart"
 
-pipeline-vault: .env airflow-dirs ## Start Airflow pipeline + Vault together
+# Creates .env.vault which activates VaultBackend inside Airflow containers.
+# The file is git-ignored and absent by default so `make pipeline` never touches Vault.
+.env.vault:
+	@{ \
+	  echo 'AIRFLOW__SECRETS__BACKEND=airflow.providers.hashicorp.secrets.vault.VaultBackend'; \
+	  echo 'AIRFLOW__SECRETS__BACKEND_KWARGS={"connections_path":"airflow/connections","variables_path":"airflow/variables","url":"http://vault:8200","auth_type":"token","kv_engine_version":2}'; \
+	} > .env.vault
+	@echo "  ✅ .env.vault created — VaultBackend will be active on next Airflow start"
+
+pipeline-vault: .env .env.vault build-pipeline airflow-dirs ## Start Airflow pipeline + Vault together
 	@echo "Starting pipeline + Vault stack..."
 	docker compose $(ENV_FILE_FLAGS) \
 		--profile pipeline --profile vault \

--- a/scripts/make/vault.mk
+++ b/scripts/make/vault.mk
@@ -1,0 +1,35 @@
+# =============================================================================
+##@ Vault — HashiCorp Vault secrets management
+# =============================================================================
+
+.PHONY: vault-up vault-down pipeline-vault
+
+vault-up: .env ## Start Vault server and seed example secrets
+	@echo "Starting Vault (dev mode)..."
+	docker compose $(ENV_FILE_FLAGS) \
+		--profile vault \
+		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
+		up -d --remove-orphans
+	@echo ""
+	@echo "Vault is up:"
+	@echo "   UI / API  → http://localhost:$${VAULT_PORT:-8200}"
+	@echo "   Token     → \$$(grep VAULT_DEV_ROOT_TOKEN .env.local | cut -d= -f2)"
+	@echo ""
+
+vault-down: ## Stop Vault
+	docker compose $(ENV_FILE_FLAGS) \
+		--profile vault \
+		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
+		down
+
+pipeline-vault: .env airflow-dirs ## Start Airflow pipeline + Vault together
+	@echo "Starting pipeline + Vault stack..."
+	docker compose $(ENV_FILE_FLAGS) \
+		--profile pipeline --profile vault \
+		$(foreach f,$(COMPOSE_FILE_LIST),-f $(f)) \
+		up -d --remove-orphans
+	@echo ""
+	@echo "Pipeline + Vault stack is up:"
+	@echo "   Airflow UI → http://localhost:$${AIRFLOW_API_SERVER_PORT:-8081}"
+	@echo "   Vault UI   → http://localhost:$${VAULT_PORT:-8200}"
+	@echo ""


### PR DESCRIPTION
## Summary

- Add HashiCorp Vault (dev mode) as a new Docker Compose service under profile `vault`
- Wire Airflow 3's `VaultBackend` so DAGs resolve connections and variables from Vault transparently — no DAG code changes required
- Make VaultBackend conditional via `.env.vault` (absent = Airflow uses DB secrets; `make pipeline-vault` creates it, `make vault-down` removes it)
- Convert `vault-init` from a one-shot container to a watch-and-seed sidecar that re-seeds policies and secrets after every Vault restart (dev mode loses state on restart)
- Airflow uses a policy-scoped `VAULT_AIRFLOW_TOKEN` (read-only to `secret/airflow/*`) instead of the root token
- Bake `apache-airflow-providers-hashicorp` into a custom Airflow image (`compose/airflow/Dockerfile`) instead of installing via `_PIP_ADDITIONAL_REQUIREMENTS` on every container start
- Enable iceberg-rest logback suppression to prevent credential dump at startup
- Fix Fluentd healthcheck to use `monitor_agent` HTTP endpoint instead of TCP probe
- Fix postgres bind-mount to read-only; nginx redundant volume mount removed; cAdvisor `privileged:true` removed

## New files

| File | Purpose |
|------|---------| 
| `compose/docker-compose.vault.yaml` | Vault server (dev mode) + `vault-init` sidecar |
| `compose/vault/vault-init.sh` | Watch-and-seed sidecar: creates `airflow-ro` policy, scoped token, and example secrets; re-seeds on Vault restart |
| `compose/airflow/Dockerfile` | Custom Airflow image with HashiCorp provider baked in |
| `compose/iceberg-rest/logback.xml` | Suppresses RESTCatalogServer startup log that dumps credentials |
| `scripts/make/vault.mk` | `vault-up`, `vault-down`, `pipeline-vault`, `.env.vault` make targets |

## Modified files

| File | Change |
|------|--------|
| `config/secrets.yaml` | Added `VAULT_DEV_ROOT_TOKEN` and `VAULT_AIRFLOW_TOKEN` (both random_hex/32) |
| `.env` | Added `VAULT_VERSION=1.17.2`, `VAULT_PORT=8200`, `AIRFLOW_VERSION=3.2.0` |
| `compose/docker-compose.pipeline.yaml` | Switched to custom image build; VaultBackend config via `../.env.vault`; uses `VAULT_AIRFLOW_TOKEN` |
| `compose/docker-compose.query.yaml` | Enabled `JAVA_TOOL_OPTIONS` + logback volume mount for iceberg-rest |
| `compose/docker-compose.logging.yaml` | Healthcheck updated to `monitor_agent` HTTP endpoint |
| `compose/docker-compose.db.yaml` | postgres init SQL mount changed from `:rw` to `:ro` |
| `compose/docker-compose.proxy.yaml` | Removed redundant `conf.d` sub-directory volume mount |
| `compose/docker-compose.observability.yaml` | Removed `privileged:true` from cAdvisor; added `no-new-privileges` |
| `compose/fluentd/fluent.conf` | Added `monitor_agent` source on port 9880 |
| `compose/fluentd/Dockerfile` | Added `curl` (required for monitor_agent healthcheck) |
| `makefile` | Added `include scripts/make/vault.mk` |
| `scripts/make/compose.mk` | Added `build-pipeline` target; `pipeline` depends on it; `AIRFLOW_VERSION` read from `.env` |
| `helm/airflow/values.yaml` | Added probe-tuning rationale comment to `dagProcessor.livenessProbe` |
| `.gitignore` | Added `.env.vault` |

## How it works

Vault joins the `pipeline` network so Airflow containers reach it as `vault:8200`. The `vault-init` sidecar runs alongside Vault and:
1. Creates an `airflow-ro` policy (read-only to `secret/airflow/*`, plus `auth/token/lookup-self` for hvac auth checks)
2. Creates a named token with the `VAULT_AIRFLOW_TOKEN` value as its ID
3. Seeds `secret/airflow/connections/postgres_default` and `secret/airflow/variables/environment`
4. Polls every 30s, re-seeds everything if Vault restarts, and renews the token to prevent 72h expiry

Airflow's `VaultBackend` is only active when `../.env.vault` is present (injected via `env_file: required: false`). `make pipeline` never touches Vault; `make pipeline-vault` creates `.env.vault` before starting both stacks.

DAG code is unchanged — `BaseHook.get_connection()` and `Variable.get()` work as normal. If Vault is unreachable, lookups fall back to the Airflow DB.

## Usage

```bash
make secrets             # generates VAULT_DEV_ROOT_TOKEN + VAULT_AIRFLOW_TOKEN in .env.local
make build-pipeline      # builds airflow-local:3.2.0 with providers baked in
make pipeline-vault      # starts Airflow + Vault together (creates .env.vault)
make vault-down          # stops Vault and removes .env.vault
```

## Test plan

- [x] `make secrets` generates `VAULT_DEV_ROOT_TOKEN` and `VAULT_AIRFLOW_TOKEN` in `.env.local`
      > **Evidence (2026-06-09):** `write VAULT_DEV_ROOT_TOKEN [random_hex]`, `write VAULT_AIRFLOW_TOKEN [random_hex]` — 3 secrets written, 10 already-present skipped.
- [x] `make lint` passes with no errors
      > **Evidence (2026-06-09):** `✅ Compose config is valid` — all 9 compose files including `docker-compose.vault.yaml` parsed cleanly.
- [x] `make build-pipeline` builds `airflow-local:3.2.0` successfully
      > **Evidence (2026-06-09):** `apache-airflow-providers-hashicorp` already satisfied (v4.5.0 baked in base image). Final line: `✅ airflow-local:3.2.0 built`.
- [x] `make vault-up` starts vault and vault-init sidecar; both reach healthy state
      > **Evidence (2026-06-09):** `vault` → `Up (healthy)`, `vault-init` → `Up` (sidecar has no healthcheck; logs confirm seeding complete).
- [x] `make pipeline-vault` starts all Airflow services + Vault healthy
      > **Evidence (2026-06-09):** All 7 services healthy — `postgres`, `vault`, `airflow-api-server`, `airflow-scheduler`, `airflow-dag-processor`, `airflow-triggerer`, `vault-init`. Note: `dag-processor` occasionally shows transient unhealthy when `airflow jobs check` exceeds 10s timeout on WSL2 (recovers; pre-existing behavior documented in probe comments).
- [x] Vault UI reachable at `http://localhost:8200`
      > **Evidence (2026-06-09):** `GET /v1/sys/health` → `{"initialized":true,"sealed":false,"version":"1.17.2",...}`
- [x] Airflow UI reachable at `http://localhost:8081`
      > **Evidence (2026-06-09):** `GET /api/v2/version` → `{"version":"3.2.0",...}` (JWT auth via `/auth/token`)
- [x] `vault kv get secret/airflow/connections/postgres_default` returns seeded data
      > **Evidence (2026-06-09):** `conn_type=postgres host=postgres login=airflow schema=airflow port=5432 password=[SET len=24]`
- [x] `VaultBackend.get_connection('postgres_default')` returns correct host/login/password
      > **Evidence (2026-06-09):** `BaseHook.get_connection('postgres_default')` → `conn_type=postgres host=postgres login=airflow schema=airflow port=5432 password=[SET]` — PASS
- [x] `VaultBackend.get_variable('environment')` returns `local`
      > **Evidence (2026-06-09):** `Variable.get('environment')` → `value=local` — PASS
- [x] `make pipeline` (without vault) starts cleanly with no Vault-related errors
      > **Evidence (2026-06-09):** After `make vault-down`, `make pipeline` restarted Airflow. `AIRFLOW__SECRETS__BACKEND=NOT SET (DB fallback active)`. Zero Vault-related lines in `airflow-{scheduler,api-server,dag-processor,triggerer}` logs.
- [x] iceberg-rest startup logs contain no plaintext passwords
      > **Evidence (2026-06-09):** `docker run` with `JAVA_TOOL_OPTIONS=-Dlogback.configurationFile=/opt/logback.xml` — startup log shows `Picked up JAVA_TOOL_OPTIONS: -Dlogback.configurationFile=/opt/logback.xml` then only Jetty INFO lines. `RESTCatalogServer` logger completely absent (WARN level). Zero `password` or `secret` matches. Full query stack test blocked by pre-existing `minio/mc:RELEASE.2025-07-14T01-07-59Z` manifest pull failure (unrelated to this PR).